### PR TITLE
Print evaluation results to STDOUT rather than to the logger

### DIFF
--- a/char_cnn/__main__.py
+++ b/char_cnn/__main__.py
@@ -49,9 +49,9 @@ def evaluate_dataset(split_name, dataset_cls, model, embedding, loader, batch_si
     saved_model_evaluator = EvaluatorFactory.get_evaluator(dataset_cls, model, embedding, loader, batch_size, device)
     saved_model_evaluator.ignore_lengths = True
     scores, metric_names = saved_model_evaluator.get_scores()
-    logger.info('Evaluation metrics for {}'.format(split_name))
-    logger.info('\t'.join([' '] + metric_names))
-    logger.info('\t'.join([split_name] + list(map(str, scores))))
+    print('Evaluation metrics for', split_name)
+    print(metric_names)
+    print(scores)
 
 
 if __name__ == '__main__':

--- a/common/evaluators/reuters_evaluator.py
+++ b/common/evaluators/reuters_evaluator.py
@@ -62,4 +62,4 @@ class ReutersEvaluator(Evaluator):
         if hasattr(self.model, 'beta_ema') and self.model.beta_ema > 0:
             self.model.load_params(old_params)
 
-        return [accuracy, precision, recall, f1, avg_loss], ['accuracy', 'precision', 'recall', 'f1' 'cross_entropy_loss']
+        return [accuracy, precision, recall, f1, avg_loss], ['accuracy', 'precision', 'recall', 'f1', 'cross_entropy_loss']

--- a/han/__main__.py
+++ b/han/__main__.py
@@ -17,6 +17,7 @@ from han.args import get_args
 from han.model import HAN
 import torch.nn.functional as F
 
+
 class UnknownWordVecCache(object):
     """
     Caches the first randomly generated word vector for a certain size to make it is reused.
@@ -52,9 +53,9 @@ def evaluate_dataset(split_name, dataset_cls, model, embedding, loader, batch_si
     saved_model_evaluator.single_label = single_label
     saved_model_evaluator.ignore_lengths = True
     scores, metric_names = saved_model_evaluator.get_scores()
-    logger.info('Evaluation metrics for {}'.format(split_name))
-    logger.info('\t'.join([' '] + metric_names))
-    logger.info('\t'.join([split_name] + list(map(str, scores))))
+    print('Evaluation metrics for', split_name)
+    print(metric_names)
+    print(scores)
 
 
 if __name__ == '__main__':

--- a/lstm_baseline/__main__.py
+++ b/lstm_baseline/__main__.py
@@ -53,9 +53,9 @@ def evaluate_dataset(split_name, dataset_cls, model, embedding, loader, batch_si
     saved_model_evaluator = EvaluatorFactory.get_evaluator(dataset_cls, model, embedding, loader, batch_size, device)
     saved_model_evaluator.single_label = single_label
     scores, metric_names = saved_model_evaluator.get_scores()
-    logger.info('Evaluation metrics for {}'.format(split_name))
-    logger.info('\t'.join([' '] + metric_names))
-    logger.info('\t'.join([split_name] + list(map(str, scores))))
+    print('Evaluation metrics for', split_name)
+    print(metric_names)
+    print(scores)
 
 
 if __name__ == '__main__':

--- a/lstm_baseline/model.py
+++ b/lstm_baseline/model.py
@@ -61,7 +61,7 @@ class LSTMBaseline(nn.Module):
         x = self.dropout(x)
         if self.has_bottleneck_layer:
             x = F.relu(self.fc1(x))
-            x = self.dropout(x)
+            # x = self.dropout(x)
             return self.fc2(x)
         else:
             return self.fc1(x)

--- a/lstm_regularization/__main__.py
+++ b/lstm_regularization/__main__.py
@@ -52,9 +52,9 @@ def evaluate_dataset(split_name, dataset_cls, model, embedding, loader, batch_si
     saved_model_evaluator = EvaluatorFactory.get_evaluator(dataset_cls, model, embedding, loader, batch_size, device)
     saved_model_evaluator.single_label = single_label
     scores, metric_names = saved_model_evaluator.get_scores()
-    logger.info('Evaluation metrics for {}'.format(split_name))
-    logger.info('\t'.join([' '] + metric_names))
-    logger.info('\t'.join([split_name] + list(map(str, scores))))
+    print('Evaluation metrics for', split_name)
+    print(metric_names)
+    print(scores)
 
 
 if __name__ == '__main__':

--- a/lstm_regularization/model.py
+++ b/lstm_regularization/model.py
@@ -83,7 +83,7 @@ class LSTMBaseline(nn.Module):
         x = self.dropout(x)
         if self.has_bottleneck_layer:
             x = F.relu(self.fc1(x))
-            x = self.dropout(x)
+            # x = self.dropout(x)
             if self.TAR:
                 return self.fc2(x), rnn_outs.permute(1,0,2)
             return self.fc2(x)

--- a/lstm_regularization/model.py
+++ b/lstm_regularization/model.py
@@ -18,7 +18,7 @@ class LSTMBaseline(nn.Module):
         self.mode = config.mode
         self.TAR = config.TAR
         self.beta_ema = config.beta_ema  ## Temporal averaging
-        self.wdrop = config.wdrop ## WEight dropping
+        self.wdrop = config.wdrop ## Weight dropping
         self.embed_droprate = config.embed_droprate ## Embedding dropout 
 
         input_channel = 1

--- a/xml_cnn/__main__.py
+++ b/xml_cnn/__main__.py
@@ -51,9 +51,9 @@ def get_logger():
 def evaluate_dataset(split_name, dataset_cls, model, embedding, loader, batch_size, device):
     saved_model_evaluator = EvaluatorFactory.get_evaluator(dataset_cls, model, embedding, loader, batch_size, device)
     scores, metric_names = saved_model_evaluator.get_scores()
-    logger.info('Evaluation metrics for {}'.format(split_name))
-    logger.info('\t'.join([' '] + metric_names))
-    logger.info('\t'.join([split_name] + list(map(str, scores))))
+    print('Evaluation metrics for', split_name)
+    print(metric_names)
+    print(scores)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This makes it easier to save results through IO redirection. 